### PR TITLE
fix(CheckBox): Added onValueChange prop in checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -26,7 +26,6 @@ export const Checkbox = componentMapper<CheckboxProps>(SelectionControl, {
 		if (onPress) {
 			onPress();
 		}
-
 		if (onValueChange) {
 			onValueChange(value, !checked);
 		}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
 import { CheckboxProps } from '@bluebase/components';
+// tslint:disable-next-line: sort-imports
 import { Checkbox as RNPCheckbox } from 'react-native-paper';
 import { SelectionControl } from '../SelectionControl';
 import { Theme } from '@bluebase/core';

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
-import { Checkbox as RNPCheckbox } from 'react-native-paper';
 import { CheckboxProps } from '@bluebase/components';
+import { Checkbox as RNPCheckbox } from 'react-native-paper';
 import { SelectionControl } from '../SelectionControl';
 import { Theme } from '@bluebase/core';
 import { componentMapper } from '@bluebase/component-mapper';
@@ -20,6 +20,15 @@ export const Checkbox = componentMapper<CheckboxProps>(SelectionControl, {
 		}
 
 		return color;
+	},
+	onPress: ({ onPress, onValueChange, value, checked }: any) => ()  => {
+		if (onPress) {
+			onPress();
+		}
+
+		if (onValueChange) {
+			onValueChange(value, checked);
+		}
 	},
 
 	status: ({ checked, indeterminate }: CheckboxProps) => {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -28,7 +28,7 @@ export const Checkbox = componentMapper<CheckboxProps>(SelectionControl, {
 		}
 
 		if (onValueChange) {
-			onValueChange(value, checked);
+			onValueChange(value, !checked);
 		}
 	},
 

--- a/src/components/Checkbox/__stories__/Checkbox.stories.tsx
+++ b/src/components/Checkbox/__stories__/Checkbox.stories.tsx
@@ -23,7 +23,11 @@ stories
 			color="blue"
 		/>
 		<Checkbox
-			onValueChange={action('Checked')}
+			value="test1"
+			onValueChange={(a, b)=>{
+				// console.log(a);
+				// console.log(b);
+			}}
 			label="Unchecked"
 			color="blue"
 			checked={false}

--- a/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -119,7 +119,7 @@ describe.only('Checkbox', () => {
 
 		const component = mount(
 			<BlueBaseApp components={{ Checkbox }}>
-				<BBCheckbox color="default" onPress={onPressFunc} onValueChange={onValueChangeFunc} />
+				<BBCheckbox color="default" onPress={onPressFunc} value={1} onValueChange={onValueChangeFunc} />
 			</BlueBaseApp>
 		);
 
@@ -131,7 +131,7 @@ describe.only('Checkbox', () => {
 
 		const  onValueChange = component.find('TouchableHighlight').last().prop('onValueChange') as any;
 		onValueChange();
-		expect(onValueChangeFunc).toBeCalled();
+		expect(onValueChangeFunc).toBeCalledWith(1, true);
 	});
 
 });

--- a/src/components/Checkbox/__tests__/Checkbox.test.tsx
+++ b/src/components/Checkbox/__tests__/Checkbox.test.tsx
@@ -1,4 +1,5 @@
 import { BlueBaseApp, getComponent } from '@bluebase/core';
+
 import { Checkbox } from '../Checkbox';
 import React from 'react';
 import { mount } from 'enzyme';
@@ -108,6 +109,29 @@ describe.only('Checkbox', () => {
 
 		// expect(component).toMatchSnapshot();
 		expect(component.find('Checkbox Text').last().text()).toEqual('Foo');
+	});
+
+	it('should check that the onPress and onValueChange is binded correctly', async () => {
+		const onPressFunc = jest.fn();
+		const onValueChangeFunc = jest.fn();
+
+		const BBCheckbox = getComponent('Checkbox');
+
+		const component = mount(
+			<BlueBaseApp components={{ Checkbox }}>
+				<BBCheckbox color="default" onPress={onPressFunc} onValueChange={onValueChangeFunc} />
+			</BlueBaseApp>
+		);
+
+		await waitForElement(component as any, BBCheckbox);
+
+		const  onPress = component.find('TouchableHighlight').last().prop('onPress') as any;
+		onPress();
+		expect(onPressFunc).toBeCalled();
+
+		const  onValueChange = component.find('TouchableHighlight').last().prop('onValueChange') as any;
+		onValueChange();
+		expect(onValueChangeFunc).toBeCalled();
 	});
 
 });


### PR DESCRIPTION
Handled onValueChange with onPress callback

onPress will behave as a callback without any parameters but onValueChange will have value and checked parameters.